### PR TITLE
Use the new osmnx.settings module

### DIFF
--- a/everystreet.ipynb
+++ b/everystreet.ipynb
@@ -25,7 +25,8 @@
     "\n",
     "from network import Network\n",
     "from network.algorithms import hierholzer\n",
-    "ox.config(use_cache=True, log_console=True)"
+    "ox.settings.use_cache = True\n",
+    "ox.settings.log_console = True"
    ]
   },
   {


### PR DESCRIPTION
Running the first cell of the Jupyter notebook yields the following error message
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 13
     11 from network import Network
     12 from network.algorithms import hierholzer
---> 13 ox.config(use_cache=True, log_console=True)

AttributeError: module 'osmnx' has no attribute 'config'
```

OSMNX does not have a `config` method anymore but rather a `settings` module:
- [osmnx.settings module docs](https://osmnx.readthedocs.io/en/stable/user-reference.html#module-osmnx.settings)
- [osmnx.utils.config docs](https://osmnx.readthedocs.io/en/stable/user-reference.html#osmnx.utils.config)
    > Do not use: deprecated. Use the settings module directly.

This PR swaps the call to `osmnx.config` method with the `osmnx.settings` module