### PR TITLE
Move away from deprecated osmnx.utils_graph.get_undirected

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ org_graph = ox.graph_from_place(location, custom_filter=CUSTOM_FILTER)
 
 """ Simplifying the original directed multi-graph to undirected, so we can go both 
     ways in one way streets """
-graph = ox.utils_graph.get_undirected(org_graph)
+graph = ox.convert.to_undirected(org_graph)
 fig, ax = ox.plot_graph(graph, node_zorder=2, node_color="k", bgcolor="w")
 ```
 

--- a/everystreet.ipynb
+++ b/everystreet.ipynb
@@ -63,7 +63,7 @@
     "org_graph = ox.graph_from_place(location, custom_filter=CUSTOM_FILTER)\n",
     "\n",
     "# Simplifying the original directed multi-graph to undirected, so we can go both ways in one way streets\n",
-    "graph = ox.utils_graph.get_undirected(org_graph)\n",
+    "graph = ox.convert.to_undirected(org_graph)\n",
     "fig, ax = ox.plot_graph(graph, node_zorder=2, node_color=\"k\", bgcolor=\"w\")"
    ]
   },


### PR DESCRIPTION
Running the third cell in the Jupyter notebook yields the following output

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[5], line 5
      2 org_graph = ox.graph_from_place(location, custom_filter=CUSTOM_FILTER)
      4 # Simplifying the original directed multi-graph to undirected, so we can go both ways in one way streets
----> 5 graph = ox.utils_graph.get_undirected(org_graph)
      6 fig, ax = ox.plot_graph(graph, node_zorder=2, node_color="k", bgcolor="w")

AttributeError: module 'osmnx' has no attribute 'utils_graph'
```

[osmnx.utils_graph.get_undirected docs](https://osmnx.readthedocs.io/en/stable/user-reference.html#osmnx.utils_graph.get_undirected) is deprecated:
> Do not use: deprecated.
> Use the convert.to_undirected function instead.

This PR swaps `osmnx.utils_graph.get_undirected` with `osmnx.convert.to_undirected`